### PR TITLE
Fall back to index.d.ts if there's no header in a d.ts file

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:no-require-imports */
 import Client = require("github");
+import path = require("path");
 /* tslint:enable:no-require-imports */
 
 export interface PRInfo {
@@ -48,6 +49,15 @@ export async function getPRInfo(req: PRInfoRequest): Promise<PRInfo> {
         number: req.number,
     });
     info.files = pullRequestFilesResponse.data;
+    info.files = info.files.filter(file => {
+        switch (path.extname(file.filename)) {
+            case ".ts":
+            case ".tsx":
+                return true;
+            default:
+                return false;
+        }
+    });
 
     // Get the pull request's files' contents
     let blobRequests = info.files.map(file => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -4,7 +4,7 @@ import Client = require("github");
 
 export interface PRInfo {
     pr: GithubAPIv3.PullRequest;
-    files: GithubAPIv3.PullRequest.File[] | null;
+    files: GithubAPIv3.PullRequest.File[];
     contents: { [path: string]: string; };
     baseContents: { [path: string]: string; };
 }
@@ -15,7 +15,7 @@ export interface PRInfoRequest {
     number: number;
 }
 
-export function getPRInfo(req: PRInfoRequest): Promise<PRInfo> {
+export async function getPRInfo(req: PRInfoRequest): Promise<PRInfo> {
     let github = new Client({
         // debug: true
     });
@@ -25,83 +25,64 @@ export function getPRInfo(req: PRInfoRequest): Promise<PRInfo> {
         secret: "7524eed1afd84b09f08f1439e7e08860add37c09",
     });
 
-    return new Promise<PRInfo>((resolve, reject) => {
-        github.pullRequests.get({
-            owner: req.owner || "DefinitelyTyped",
-            repo: req.repo || "DefinitelyTyped",
-            number: req.number,
-        }, (err: any, res: GithubAPIv3.Response<GithubAPIv3.PullRequest>) => {
-            if (err) {
-                reject(err);
+    let owner = req.owner || "DefinitelyTyped";
+    let repo = req.repo || "DefinitelyTyped";
+
+    // Get the pull request
+    let pullRequestResponse = await github.pullRequests.get({
+        owner: owner,
+        repo: repo,
+        number: req.number,
+    });
+    let info: PRInfo = {
+        pr: pullRequestResponse.data,
+        files: [],
+        contents: {},
+        baseContents: {},
+    };
+
+    // Get the pull request's files
+    let pullRequestFilesResponse = await github.pullRequests.getFiles({
+        owner: owner,
+        repo: repo,
+        number: req.number,
+    });
+    info.files = pullRequestFilesResponse.data;
+
+    // Get the pull request's files' contents
+    let blobRequests = info.files.map(file => {
+        return github.gitdata.getBlob({
+            owner: owner,
+            repo: repo,
+            sha: file.sha,
+        }).then((res: GithubAPIv3.Response<GithubAPIv3.GitData.Blob>) => {
+            if (res.data.encoding === "utf-8") {
+                info.contents[file.filename] = res.data.content;
             } else {
-                resolve({
-                    pr: res.data,
-                    files: null,
-                    contents: {},
-                    baseContents: {},
-                });
+                let b = new Buffer(res.data.content, "base64");
+                info.contents[file.filename] = b.toString();
             }
         });
-    })
-        .then(info => {
-            return new Promise<PRInfo>((resolve, reject) => {
-                github.pullRequests.getFiles({
-                    owner: req.owner || "DefinitelyTyped",
-                    repo: req.repo || "DefinitelyTyped",
-                    number: req.number,
-                }, (err: any, res: GithubAPIv3.Response<GithubAPIv3.PullRequest.File[]>) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        info.files = res.data;
-                        resolve(info);
-                    }
-                });
-            });
-        }).then(info => {
-            let promises = info.files!.map(file => {
-                return new Promise<PRInfo>((resolve, reject) => {
-                    github.gitdata.getBlob({
-                        owner: req.owner || "DefinitelyTyped",
-                        repo: req.repo || "DefinitelyTyped",
-                        sha: file.sha,
-                    }, (err: any, res: GithubAPIv3.Response<GithubAPIv3.GitData.Blob>) => {
-                        if (err) {
-                            reject(err);
-                        } else if (res.data.encoding === "utf-8") {
-                            info.contents[file.filename] = res.data.content;
-                            resolve(info);
-                        } else {
-                            let b = new Buffer(res.data.content, "base64");
-                            info.contents[file.filename] = b.toString();
-                            resolve(info);
-                        }
-                    });
-                });
-            });
-            return Promise.all(promises).then(() => info);
-        }).then(info => {
-            let promises = info.files!.filter(file => file.status === "modified").map(file => {
-                return new Promise<PRInfo>((resolve, reject) => {
-                    github.repos.getContent({
-                        owner: "DefinitelyTyped",
-                        repo: "DefinitelyTyped",
-                        path: file.filename,
-                        ref: info.pr.base.ref,
-                    }, (err: any, res: GithubAPIv3.Response<GithubAPIv3.Repository.FileContents>) => {
-                        if (err) {
-                            reject(err);
-                        } else if (res.data.encoding === "utf-8") {
-                            info.baseContents[file.filename] = res.data.content;
-                            resolve(info);
-                        } else {
-                            let b = new Buffer(res.data.content, "base64");
-                            info.baseContents[file.filename] = b.toString();
-                            resolve(info);
-                        }
-                    });
-                });
-            });
-            return Promise.all(promises).then(() => info);
+    });
+    await Promise.all(blobRequests);
+
+    // Get the pull request's files' base contents
+    let fileContentsRequests = info.files.filter(file => file.status === "modified").map(file => {
+        return github.repos.getContent({
+            owner: owner,
+            repo: repo,
+            path: file.filename,
+            ref: info.pr.base.ref,
+        }).then((res: GithubAPIv3.Response<GithubAPIv3.Repository.FileContents>) => {
+            if (res.data.encoding === "utf-8") {
+                info.baseContents[file.filename] = res.data.content;
+            } else {
+                let b = new Buffer(res.data.content, "base64");
+                info.baseContents[file.filename] = b.toString();
+            }
         });
+    });
+    await Promise.all(fileContentsRequests);
+
+    return info;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -215,7 +215,7 @@ export function constructReviewResult(pr: github.PRInfoRequest): Promise<ReviewR
     return github
         .getPRInfo(pr)
         .then(info => {
-            let ps = info.files!
+            let ps = info.files
                 .filter(file => /\.d\.ts(x)?$/.test(file.filename))
                 .map(file => {
                     let reviewResult: ReviewResult = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/lodash": {
+      "version": "4.14.71",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.71.tgz",
+      "integrity": "sha512-x9E8HYuhmcQJPjhTd+t0oRXiQCJXoRPSzCOgYKggxtvNb/kGw8RrbdZzCXrQ6i/i4o0TettxyouY7UdbqkS4AQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "7.0.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.31.tgz",
@@ -881,6 +887,14 @@
         "hooker": "0.2.3",
         "lodash": "3.10.1",
         "underscore.string": "3.2.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
       }
     },
     "grunt-legacy-log-utils": {
@@ -1148,10 +1162,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "commandpost": "^1.0.0",
     "definition-header": "^0.5.0",
     "github": "^9.2.0",
+    "lodash": "^4.17.4",
     "npm": "^4.4.4"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.71",
     "@types/node": "^7.0.12",
     "@types/npm": "^2.0.28",
     "@types/parsimmon": "^1.0.4",


### PR DESCRIPTION
The bot will report an error and fail to mention any authors if it tries to parse a d.ts file without a header (e.g. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18400).

This PR makes it so that when an error is encountered in a d.ts file, the bot will try to use the header from `index.d.ts` instead. This is intended to handle the case where there is no header in a secondary file.

**Old output**

> _types/semantic-ui-api/global.d.ts_
> 
> can't parse definition header...

**New output**

> *types/semantic-ui-api/global.d.ts*
> 
> to author (@leonard-thieu). Could you review this PR?
> :+1: or :-1:?
> 
> Checklist
> 
> * [ ] pass the Travis CI test?